### PR TITLE
Fix npm install error on event-stream@3.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1878,13 +1878,12 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "event-stream": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-      "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
+      "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
       "dev": true,
       "requires": {
         "duplexer": "^0.1.1",
-        "flatmap-stream": "^0.1.0",
         "from": "^0.1.7",
         "map-stream": "0.0.7",
         "pause-stream": "^0.0.11",
@@ -3432,12 +3431,6 @@
         "rimraf": "~2.6.2",
         "write": "^0.2.1"
       }
-    },
-    "flatmap-stream": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
-      "integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw==",
-      "dev": true
     },
     "follow-redirects": {
       "version": "1.5.10",


### PR DESCRIPTION
There was an error while trying to execute the `npm install` command to fetch the project's dependencies. The issue was due to a deprecation on the event-stream package version 3.3.6, which is no longer available from the NPM registry.